### PR TITLE
Bootstrap product-suite Homebrew formulae

### DIFF
--- a/Formula/holmes.rb
+++ b/Formula/holmes.rb
@@ -1,0 +1,16 @@
+class Holmes < Formula
+  desc "SocioProphet language intelligence fabric CLI"
+  homepage "https://github.com/SocioProphet/holmes"
+  url "https://github.com/SocioProphet/holmes.git", branch: "main"
+  version "0.1.0-dev"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", "-o", bin/"holmes", "./cmd/holmes"
+  end
+
+  test do
+    system "#{bin}/holmes", "--version"
+  end
+end

--- a/Formula/prophet-cli.rb
+++ b/Formula/prophet-cli.rb
@@ -1,0 +1,16 @@
+class ProphetCli < Formula
+  desc "Facade CLI for SocioProphet, SourceOS, Holmes, and the functional AI product suite"
+  homepage "https://github.com/SocioProphet/prophet-cli"
+  url "https://github.com/SocioProphet/prophet-cli.git", branch: "main"
+  version "0.1.0-dev"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", "-o", bin/"prophet", "./cmd/prophet"
+  end
+
+  test do
+    system "#{bin}/prophet", "--help"
+  end
+end

--- a/Formula/sourceos-ai.rb
+++ b/Formula/sourceos-ai.rb
@@ -1,0 +1,16 @@
+class SourceosAi < Formula
+  desc "SourceOS on-device AI carry client and local service reference validator"
+  homepage "https://github.com/SourceOS-Linux/sourceos-model-carry"
+  url "https://github.com/SourceOS-Linux/sourceos-model-carry.git", branch: "main"
+  version "0.1.0-dev"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", "-o", bin/"sourceos-ai", "./cmd/sourceos-ai"
+  end
+
+  test do
+    system "#{bin}/sourceos-ai", "--version"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
-# homebrew-prophet
-Homebrew tap for the SocioProphet / SourceOS / Holmes product suite: Prophet CLI, SourceOS AI carry, SourceOS devtools, SourceOS installer, Holmes, model routing, guardrails, agent registry, and functional ML lab launchers.
+# Homebrew Prophet
+
+Homebrew tap for the SocioProphet, SourceOS, and Holmes product suite.
+
+## Tap
+
+```bash
+brew tap SocioProphet/prophet
+```
+
+## Current formulae
+
+```bash
+brew install prophet-cli
+brew install sourceos-ai
+brew install holmes
+```
+
+`prophet-cli` installs the `prophet` facade command.
+
+`sourceos-ai` installs the SourceOS local AI carry client.
+
+`holmes` installs the Holmes language intelligence CLI.
+
+## Pending formulae
+
+- `sourceos-devtools`
+- `sourceos-installer`
+- `model-router`
+- `guardrail-fabric`
+- `agent-registry`
+- `nlplab`
+- `embeddinglab`
+- `graphlab`
+- `timeserieslab`
+- `imagelab`
+- `speechlab`
+- `ocrlab`
+- `videolab`
+- `translationlab`


### PR DESCRIPTION
## Summary

Bootstraps the SocioProphet Homebrew tap with the first source-built formulae for the product suite:

- `prophet-cli` installs the `prophet` facade command from `SocioProphet/prophet-cli`
- `sourceos-ai` installs the SourceOS local AI carry client from `SourceOS-Linux/sourceos-model-carry`
- `holmes` installs the Holmes language intelligence CLI from `SocioProphet/holmes`

Also updates the README with the tap and current formulae.

## Notes

These are source-built development formulae that build from the `main` branch of each repo. Stable release artifact formulae with pinned versions, checksums, SBOM, and attestations should replace these as the release chain matures.

## Validation

Formula syntax is intentionally minimal and uses Go build entrypoints already present in the source repos.

Follow-up local validation:

```bash
brew update
brew install SocioProphet/prophet/prophet-cli
brew install SocioProphet/prophet/sourceos-ai
brew install SocioProphet/prophet/holmes
```
