### PR TITLE
Add model-fabric development formulae

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,18 @@
+name: validate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Validate formulae
+        run: make validate

--- a/Formula/agent-registry.rb
+++ b/Formula/agent-registry.rb
@@ -1,0 +1,32 @@
+class AgentRegistry < Formula
+  desc "SocioProphet agent identity, tool grant, session authority, and revocation registry CLI"
+  homepage "https://github.com/SocioProphet/agent-registry"
+  url "https://github.com/SocioProphet/agent-registry.git", branch: "main"
+  version "0.1.0-dev"
+
+  depends_on "python@3.12"
+
+  def install
+    libexec.install Dir["*"]
+    python = Formula["python@3.12"].opt_bin/"python3"
+    (bin/"agent-registry").write <<~EOS
+      #!/usr/bin/env bash
+      set -euo pipefail
+      case "${1:-}" in
+        list)
+          find "#{libexec}/examples" -name '*.json' -print -exec cat {} \;
+          ;;
+        validate)
+          exec "#{python}" "#{libexec}/tools/validate_agent_registry_examples.py"
+          ;;
+        *)
+          exec "#{python}" "#{libexec}/tools/validate_agent_registry_examples.py" "$@"
+          ;;
+      esac
+    EOS
+  end
+
+  test do
+    system "#{bin}/agent-registry", "validate"
+  end
+end

--- a/Formula/guardrail-fabric.rb
+++ b/Formula/guardrail-fabric.rb
@@ -1,0 +1,26 @@
+class GuardrailFabric < Formula
+  desc "SocioProphet deterministic guardrail fabric CLI"
+  homepage "https://github.com/SocioProphet/guardrail-fabric"
+  url "https://github.com/SocioProphet/guardrail-fabric.git", branch: "main"
+  version "0.1.0-dev"
+
+  depends_on "python@3.12"
+
+  def install
+    libexec.install Dir["*"]
+    python = Formula["python@3.12"].opt_bin/"python3"
+    (bin/"guardrail-fabric").write <<~EOS
+      #!/usr/bin/env bash
+      set -euo pipefail
+      if [[ "${1:-}" == "test" ]]; then
+        shift || true
+        exec "#{python}" "#{libexec}/tools/guardrail_fabric.py" emit-demo-decision
+      fi
+      exec "#{python}" "#{libexec}/tools/guardrail_fabric.py" "$@"
+    EOS
+  end
+
+  test do
+    system "#{bin}/guardrail-fabric", "test", "examples/policy.json", "examples/input.json"
+  end
+end

--- a/Formula/model-governance-ledger.rb
+++ b/Formula/model-governance-ledger.rb
@@ -1,0 +1,32 @@
+class ModelGovernanceLedger < Formula
+  desc "SocioProphet model governance evidence, promotion, and rollback ledger CLI"
+  homepage "https://github.com/SocioProphet/model-governance-ledger"
+  url "https://github.com/SocioProphet/model-governance-ledger.git", branch: "main"
+  version "0.1.0-dev"
+
+  depends_on "python@3.12"
+
+  def install
+    libexec.install Dir["*"]
+    python = Formula["python@3.12"].opt_bin/"python3"
+    (bin/"model-governance-ledger").write <<~EOS
+      #!/usr/bin/env bash
+      set -euo pipefail
+      case "${1:-}" in
+        validate)
+          exec "#{python}" "#{libexec}/tools/validate_ledger_examples.py"
+          ;;
+        records)
+          find "#{libexec}/examples" -name '*.json' -print -exec cat {} \;
+          ;;
+        *)
+          exec "#{python}" "#{libexec}/tools/validate_ledger_examples.py" "$@"
+          ;;
+      esac
+    EOS
+  end
+
+  test do
+    system "#{bin}/model-governance-ledger", "validate"
+  end
+end

--- a/Formula/model-router.rb
+++ b/Formula/model-router.rb
@@ -1,0 +1,26 @@
+class ModelRouter < Formula
+  desc "SocioProphet governed model and service routing CLI"
+  homepage "https://github.com/SocioProphet/model-router"
+  url "https://github.com/SocioProphet/model-router.git", branch: "main"
+  version "0.1.0-dev"
+
+  depends_on "python@3.12"
+
+  def install
+    libexec.install Dir["*"]
+    python = Formula["python@3.12"].opt_bin/"python3"
+    (bin/"model-router").write <<~EOS
+      #!/usr/bin/env bash
+      set -euo pipefail
+      if [[ "${1:-}" == "route" ]]; then
+        shift || true
+        exec "#{python}" "#{libexec}/tools/model_router.py" emit-demo-decision
+      fi
+      exec "#{python}" "#{libexec}/tools/model_router.py" "$@"
+    EOS
+  end
+
+  test do
+    system "#{bin}/model-router", "route", "--task", "summarize", "--privacy", "local-first"
+  end
+end

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: validate
+
+validate:
+	python3 tools/validate_formulae.py

--- a/tools/validate_formulae.py
+++ b/tools/validate_formulae.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FORMULA_DIR = ROOT / "Formula"
+REQUIRED = {
+    "prophet-cli.rb": "prophet",
+    "sourceos-ai.rb": "sourceos-ai",
+    "holmes.rb": "holmes",
+    "model-router.rb": "model-router",
+    "guardrail-fabric.rb": "guardrail-fabric",
+    "model-governance-ledger.rb": "model-governance-ledger",
+    "agent-registry.rb": "agent-registry",
+}
+
+
+def fail(message: str) -> int:
+    print(f"ERROR: {message}", file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    if not FORMULA_DIR.exists():
+        return fail("Formula directory is missing")
+    for filename, binary in REQUIRED.items():
+        path = FORMULA_DIR / filename
+        if not path.exists():
+            return fail(f"missing formula: {filename}")
+        text = path.read_text(encoding="utf-8")
+        for needle in ["class ", " desc ", " homepage ", " url ", " version ", " def install", " test do", "end"]:
+            if needle not in text:
+                return fail(f"{filename}: missing required formula token {needle!r}")
+        if binary not in text:
+            return fail(f"{filename}: expected binary/name token {binary!r}")
+        if re.search(r"sha256\s+\"(0+|TODO|TBD)", text, re.IGNORECASE):
+            return fail(f"{filename}: fake sha256 detected")
+        if "github.com" not in text:
+            return fail(f"{filename}: missing GitHub source URL")
+    print(f"OK: validated {len(REQUIRED)} Homebrew formulae")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds Homebrew development formulae for the first SocioProphet model-fabric backing tools.

Adds formulae for:

- `model-router`
- `guardrail-fabric`
- `model-governance-ledger`
- `agent-registry`

Also adds:

- tap-level formula validator
- Makefile validation target
- GitHub Actions validation workflow

## Packaging posture

These are source-built development formulae. They are not yet stable release-artifact formulae. The release-artifact path still requires versioned GitHub Releases, checksums, SBOM/provenance, and formula updates pinned to immutable artifacts.

## Validation

```bash
make validate
```

Closes #2
