### PR TITLE
Add SourceOS Agent Machine and Office install surface

### DIFF
--- a/Formula/agent-term.rb
+++ b/Formula/agent-term.rb
@@ -1,0 +1,19 @@
+class AgentTerm < Formula
+  include Language::Python::Virtualenv
+
+  desc "Terminal-native Matrix-first ChatOps console for SourceOS multi-agent operations"
+  homepage "https://github.com/SourceOS-Linux/agent-term"
+  url "https://github.com/SourceOS-Linux/agent-term.git", branch: "main"
+  version "0.1.0-dev"
+
+  depends_on "python@3.12"
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    system "#{bin}/agent-term", "--help"
+    system "#{bin}/agent-term", "planes", "show", "prophet-workspace"
+  end
+end

--- a/Formula/prophet-cli.rb
+++ b/Formula/prophet-cli.rb
@@ -1,16 +1,19 @@
 class ProphetCli < Formula
-  desc "Facade CLI for SocioProphet, SourceOS, Holmes, and the functional AI product suite"
+  include Language::Python::Virtualenv
+
+  desc "Facade CLI for SocioProphet and SourceOS local tools"
   homepage "https://github.com/SocioProphet/prophet-cli"
   url "https://github.com/SocioProphet/prophet-cli.git", branch: "main"
   version "0.1.0-dev"
 
-  depends_on "go" => :build
+  depends_on "python@3.12"
 
   def install
-    system "go", "build", "-o", bin/"prophet", "./cmd/prophet"
+    virtualenv_install_with_resources
   end
 
   test do
     system "#{bin}/prophet", "--help"
+    assert_match "required delegate not found", shell_output("#{bin}/prophet sourceos office doctor 2>&1", 127)
   end
 end

--- a/Formula/sourceos-devtools.rb
+++ b/Formula/sourceos-devtools.rb
@@ -1,0 +1,22 @@
+class SourceosDevtools < Formula
+  desc "SourceOS developer and AI operator CLI"
+  homepage "https://github.com/SourceOS-Linux/sourceos-devtools"
+  url "https://github.com/SourceOS-Linux/sourceos-devtools.git", branch: "main"
+  version "0.1.0-dev"
+
+  depends_on "python@3.12"
+
+  def install
+    libexec.install Dir["*"]
+    (bin/"sourceosctl").write <<~EOS
+      #!/bin/bash
+      exec "#{Formula["python@3.12"].opt_bin}/python3.12" "#{libexec}/bin/sourceosctl" "$@"
+    EOS
+  end
+
+  test do
+    system "#{bin}/sourceosctl", "--help"
+    system "#{bin}/sourceosctl", "agent-machine", "mounts", "plan"
+    system "#{bin}/sourceosctl", "office", "doctor"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -12,15 +12,36 @@ brew tap SocioProphet/prophet
 
 ```bash
 brew install prophet-cli
+brew install sourceos-devtools
+brew install agent-term
 brew install sourceos-ai
 brew install holmes
 ```
 
 `prophet-cli` installs the `prophet` facade command.
 
+`sourceos-devtools` installs `sourceosctl`, including the dry-run/read-only Agent Machine and Office Plane local helper surfaces.
+
+`agent-term` installs the Matrix-first SourceOS operator ChatOps console.
+
 `sourceos-ai` installs the SourceOS local AI carry client.
 
 `holmes` installs the Holmes language intelligence CLI.
+
+## SourceOS Agent Machine and Office Plane path
+
+The Mac-first local operator path is:
+
+```bash
+brew tap SocioProphet/prophet
+brew install prophet-cli sourceos-devtools agent-term
+
+prophet sourceos agent-machine mounts plan
+prophet sourceos office doctor
+prophet sourceos agent-term office create-deck '!prophet-workspace' --workroom workroom-demo-0001 --title 'Demo Briefing Deck'
+```
+
+The tap installs command-line tools only. It does **not** initialize Podman machines, create host mounts, write user profiles, start background daemons, or grant access to local folders. Agent Machine mounts, Office generation/conversion, and AgentTerm side effects remain explicit dry-run or policy-gated flows in the owning tools.
 
 ## Dev formulae vs stable release formulae
 
@@ -35,6 +56,8 @@ suffix and do **not** pin a sha256 checksum (the source is a live git branch).
 | Formula | Binary | Status |
 |---|---|---|
 | `prophet-cli.rb` | `prophet` | active |
+| `sourceos-devtools.rb` | `sourceosctl` | active |
+| `agent-term.rb` | `agent-term` | active |
 | `sourceos-ai.rb` | `sourceos-ai` | active |
 | `holmes.rb` | `holmes` | active |
 | `model-router.rb` | `model-router` | active |
@@ -74,7 +97,6 @@ a PR automatically.
 
 ## Pending formulae
 
-- `sourceos-devtools`
 - `sourceos-installer`
 - `nlplab`
 - `embeddinglab`


### PR DESCRIPTION
## Summary

Adds the Mac-first Homebrew install surface for SourceOS Agent Machine, Office Plane, and AgentTerm operator flows.

## Changes

- Adds `Formula/sourceos-devtools.rb` to install `sourceosctl`.
- Adds `Formula/agent-term.rb` to install `agent-term`.
- Updates `Formula/prophet-cli.rb` to install the new Python `prophet` facade instead of assuming a Go binary.
- Updates README current formula list and SourceOS Agent Machine / Office Plane install path.

## Operator path

```bash
brew tap SocioProphet/prophet
brew install prophet-cli sourceos-devtools agent-term

prophet sourceos agent-machine mounts plan
prophet sourceos office doctor
prophet sourceos agent-term office create-deck '!prophet-workspace' --workroom workroom-demo-0001 --title 'Demo Briefing Deck'
```

## Safety posture

The tap installs CLI tools only. It does not:

- initialize Podman machines;
- create host mounts;
- write user profiles;
- start background daemons;
- grant access to local folders;
- run Office generation/conversion flows.

Those remain explicit dry-run or policy-gated flows in `sourceosctl`, `agent-term`, AgentPlane, and Policy Fabric.

## Validation

Formula tests exercise:

- `prophet --help` and missing delegate behavior;
- `sourceosctl --help`, Agent Machine mount plan, and Office doctor;
- `agent-term --help` and Prophet Workspace plane lookup.