### PR TITLE
Add Local Model Door install-path tests

### DIFF
--- a/Formula/prophet-cli.rb
+++ b/Formula/prophet-cli.rb
@@ -14,6 +14,7 @@ class ProphetCli < Formula
 
   test do
     system "#{bin}/prophet", "--help"
+    assert_match "required delegate not found", shell_output("#{bin}/prophet sourceos local-model doctor 2>&1", 127)
     assert_match "required delegate not found", shell_output("#{bin}/prophet sourceos office doctor 2>&1", 127)
   end
 end

--- a/Formula/sourceos-devtools.rb
+++ b/Formula/sourceos-devtools.rb
@@ -16,6 +16,9 @@ class SourceosDevtools < Formula
 
   test do
     system "#{bin}/sourceosctl", "--help"
+    system "#{bin}/sourceosctl", "local-model", "doctor"
+    system "#{bin}/sourceosctl", "local-model", "profiles"
+    system "#{bin}/sourceosctl", "local-model", "plan", "--profile", "local-llama32-1b"
     system "#{bin}/sourceosctl", "agent-machine", "mounts", "plan"
     system "#{bin}/sourceosctl", "office", "doctor"
   end

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ brew install holmes
 
 `prophet-cli` installs the `prophet` facade command.
 
-`sourceos-devtools` installs `sourceosctl`, including the dry-run/read-only Agent Machine and Office Plane local helper surfaces.
+`sourceos-devtools` installs `sourceosctl`, including the non-mutating Local Model Door, Agent Machine, and Office Plane helper surfaces.
 
 `agent-term` installs the Matrix-first SourceOS operator ChatOps console.
 
@@ -28,7 +28,7 @@ brew install holmes
 
 `holmes` installs the Holmes language intelligence CLI.
 
-## SourceOS Agent Machine and Office Plane path
+## SourceOS Agent Machine, Office Plane, and Local Model Door path
 
 The Mac-first local operator path is:
 
@@ -36,12 +36,14 @@ The Mac-first local operator path is:
 brew tap SocioProphet/prophet
 brew install prophet-cli sourceos-devtools agent-term
 
+prophet sourceos local-model doctor
+prophet sourceos local-model plan --profile local-llama32-1b
 prophet sourceos agent-machine mounts plan
 prophet sourceos office doctor
 prophet sourceos agent-term office create-deck '!prophet-workspace' --workroom workroom-demo-0001 --title 'Demo Briefing Deck'
 ```
 
-The tap installs command-line tools only. It does **not** initialize Podman machines, create host mounts, write user profiles, start background daemons, or grant access to local folders. Agent Machine mounts, Office generation/conversion, and AgentTerm side effects remain explicit dry-run or policy-gated flows in the owning tools.
+The tap installs command-line tools only. It does **not** initialize Podman machines, create host mounts, write user profiles, start background daemons, grant access to local folders, download model weights, start local model services, or run model calls. Agent Machine mounts, Office generation/conversion, Local Model Door route planning, and AgentTerm side effects remain explicit dry-run, non-mutating, or policy-gated flows in the owning tools.
 
 ## Dev formulae vs stable release formulae
 


### PR DESCRIPTION
## Summary

Adds Homebrew tap coverage for the SourceOS Local Model Door install path.

## Changes

- Updates `sourceos-devtools.rb` tests to verify:
  - `sourceosctl local-model doctor`
  - `sourceosctl local-model profiles`
  - `sourceosctl local-model plan --profile local-llama32-1b`
- Updates `prophet-cli.rb` tests to verify the `prophet sourceos local-model ...` facade path reports the expected missing delegate when `sourceosctl` is not installed in the formula sandbox.
- Updates README to document the Local Model Door path beside Agent Machine and Office Plane.

## Safety posture

The tap installs tools only. It does not download model weights, start local model services, run model calls, initialize Podman, create mounts, or grant local folder access.

## Validation

Expected tap validation:

```bash
make validate
```